### PR TITLE
Dwaitfix verbump

### DIFF
--- a/superdamn-webkit.user.js
+++ b/superdamn-webkit.user.js
@@ -1,14 +1,14 @@
 // ==UserScript==
 // @name           SuperdAmn
 // @namespace      24bps.com
-// @description    Next generation dAmn awesomeness. Version 1.1.
+// @description    Next generation dAmn awesomeness. Version 1.0.2.
 // @author         Andy Graulund <andy@graulund.com>
-// @version        1.0.1
+// @version        1.0.2
 // @include        http://chat.deviantart.com/chat/*
 // @include        http://chat.deviantart.lan/chat/*
 // ==/UserScript==
 
-// LAST UPDATED: 2013-06-04
+// LAST UPDATED: 2013-04-12
 
 var superdAmn_GM = !!window.navigator.userAgent.match(/(firefox|iceweasel)/i)
 

--- a/superdamn.user.js
+++ b/superdamn.user.js
@@ -1,9 +1,9 @@
 // ==UserScript==
 // @name           SuperdAmn
 // @namespace      24bps.com
-// @description    Next generation dAmn awesomeness. Version 1.1.
+// @description    Next generation dAmn awesomeness. Version 1.0.2.
 // @author         Andy Graulund <andy@graulund.com>
-// @version        1.0.1
+// @version        1.0.2
 // @include        http://chat.deviantart.com/chat/*
 // @include        http://chat.deviantart.lan/chat/*
 // @grant GM_xmlhttpRequest
@@ -12,7 +12,7 @@
 // @grant GM_log
 // ==/UserScript==
 
-// LAST UPDATED: 2013-06-04
+// LAST UPDATED: 2014-04-12
 
 var superdAmn_GM = !!window.navigator.userAgent.match(/(firefox|iceweasel)/i)
 


### PR DESCRIPTION
Restores the script to its working state in Chrome and Firefox by adding calls to DWait.ready() around the code that initializes SuperdAmn and MiddleMan.
